### PR TITLE
build(ci): add coverage check to pull requests

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,6 +1,9 @@
 name: Scala CI
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -2,8 +2,6 @@ name: Scala CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,16 +1,10 @@
 name: Scala CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: ["push", "pull_request"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11


### PR DESCRIPTION
As coveralls receives interactions within a pull request as 'push', simply change the workflow to all kind of push actions and the coverage check should appear in PRs as well as in master